### PR TITLE
Use /dev/shm as temp_dir 

### DIFF
--- a/ennaf/src/utils.c
+++ b/ennaf/src/utils.c
@@ -5,6 +5,7 @@
  */
 
 
+
 //__attribute__ ((format (printf, 1, 2)))
 static void msg(const char *format, ...) 
 {


### PR DESCRIPTION
This PR will result in using `/dev/shm` as temp_dir when RAM is available and temp_dir is not forced by the `--temp-dir` argument.

(Issue described here https://github.com/KirillKryukov/naf/issues/4)
