### PR TITLE
Added support for Nix via flake

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,39 @@
+{
+  stdenv,
+  lib,
+  zstd,
+  pkg-config
+}:
+
+stdenv.mkDerivation {
+  pname = "naf";
+  version = "1.3.0";
+  src = ./.;
+  nativeBuildInputs = [pkg-config];
+  buildInputs = [zstd];
+  makeFlags = [
+    "prefix=$(out)"
+  ];
+  postPatch = ''
+    sed -i '/zstd\/lib/d' Makefile
+    substituteInPlace **/Makefile \
+      --replace "../zstd/lib/libzstd.a" "-lzstd" \
+      --replace "-I../zstd/lib" ""
+  '';
+  preBuild = ''
+    # This provides the correct -I and -L flags for the Nix store versions
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE $(pkg-config --cflags libzstd)"
+    export NIX_LDFLAGS="$NIX_LDFLAGS $(pkg-config --libs libzstd)"
+  '';
+  installPhanse = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp ennaf/ennaf $out/bin/
+    cp unnaf/unnaf $out/bin/
+    runHook postInstall
+  '';
+  meta = with lib; {
+    description = "Nucleotide Archive Format compression and decompression software";
+    platforms = platforms.linux;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1768564909,
+        "narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e4bae1bd10c9c57b2cf517953ab70060a828ee6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,9 @@
-
 {
   description = "Nix flake for NAF";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   };
-  outputs = {self, nixpkgs}:
+  outputs = { self, nixpkgs }:
     let
       allSystems = [ "x86_64-linux" ];
       forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
@@ -12,15 +11,15 @@
       });
     in
     {
-      packages = forAllSystems ({pkgs}: {
+      packages = forAllSystems ({ pkgs }: {
         default = pkgs.callPackage ./default.nix { };
       });
 
-      devShells = forAllSystems ({pkgs}: {
+      devShells = forAllSystems ({ pkgs }: {
         default = pkgs.mkShell {
-          inputsFrom = [ self.packages.${pkgs.system}.default];
+          inputsFrom = [ self.packages.${pkgs.system}.default ];
           # tools for development (modify as needed)
-#          nativeBuildInputs = with pkgs; [ ]; 
+          #          nativeBuildInputs = with pkgs; [ ]; 
         };
       });
     };

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
     in
     {
       packages = forAllSystems ({ pkgs }: {
-        default = pkgs.callPackage ./default.nix { };
+        default = pkgs.callPackage ./default.nix { inherit pkgs; };
       });
 
       devShells = forAllSystems ({ pkgs }: {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+
+{
+  description = "Nix flake for NAF";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+  outputs = {self, nixpkgs}:
+    let
+      allSystems = [ "x86_64-linux" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
+        pkgs = import nixpkgs { inherit system; };
+      });
+    in
+    {
+      packages = forAllSystems ({pkgs}: {
+        default = pkgs.callPackage ./default.nix { };
+      });
+
+      devShells = forAllSystems ({pkgs}: {
+        default = pkgs.mkShell {
+          inputsFrom = [ self.packages.${pkgs.system}.default];
+          # tools for development (modify as needed)
+#          nativeBuildInputs = with pkgs; [ ]; 
+        };
+      });
+    };
+}


### PR DESCRIPTION
Mostly added this to make it easy to run unnaf and ennaf on my own systems.
Changes made:
- added default.nix to guide compilation
- added flake.nix to guide insertion into an environment
- flake.lock was generated to lock versions of requirements
Tests done:
- it works on my machine